### PR TITLE
Add data parameter to fetch request

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -1,3 +1,4 @@
+extern crate base64;
 extern crate hyper;
 
 use std::io::Cursor;
@@ -8,6 +9,9 @@ use crate::{
     moderation::SupportedMimeTypes,
     rpc::errors::ImgProxyError,
 };
+
+use base64::encode;
+
 use hyper::Client;
 use hyper::{
     body::{to_bytes, Bytes},
@@ -182,5 +186,13 @@ impl Document {
             .header(hyper::header::CONTENT_LENGTH, self.bytes.len())
             .body(Body::from(self.bytes.clone()))
             .unwrap_or_default()
+    }
+
+    pub fn to_url(&self) -> String {
+        format!(
+            "data:{};base64,{}",
+            self.content_type,
+            encode(self.bytes.to_vec())
+        )
     }
 }

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -42,7 +42,7 @@ impl Methods {
             metrics::DOCUMENTS_FORCED.inc();
             return match (
                 Document::fetch(&proxy.config, req_id, &params.url).await,
-                &params.data,
+                &params.response_type,
             ) {
                 (Ok(doc), ResponseType::Raw) => Ok(doc.to_response()),
                 (Ok(doc), ResponseType::Json) => Ok(FetchResponse::to_response(
@@ -90,7 +90,7 @@ impl Methods {
             } else {
                 match (
                     Document::fetch(&proxy.config, req_id, &params.url).await,
-                    &params.data,
+                    &params.response_type,
                 ) {
                     (Ok(doc), ResponseType::Raw) => Ok(doc.to_response()),
                     (Ok(doc), ResponseType::Json) => Ok(FetchResponse::to_response(
@@ -161,7 +161,7 @@ impl Methods {
                                     req_id,
                                 ))
                             } else {
-                                match params.data {
+                                match params.response_type {
                                     ResponseType::Raw => Ok(document.to_response()),
                                     ResponseType::Json => Ok(FetchResponse::to_response(
                                         RpcStatus::Ok,

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -7,7 +7,6 @@ use std::sync::Arc;
 use hyper::Body;
 use hyper::Response;
 use log::{error, info, warn};
-use rustc_serialize::hex::ToHex;
 use uuid::Uuid;
 
 use crate::{
@@ -50,7 +49,7 @@ impl Methods {
                     RpcStatus::Ok,
                     ModerationStatus::Allowed,
                     Vec::new(),
-                    Some(doc.bytes.to_hex()),
+                    Some(doc.to_url()),
                     req_id,
                 )),
                 (Err(e), _) => Ok(e.to_response(req_id.clone())),
@@ -98,7 +97,7 @@ impl Methods {
                         RpcStatus::Ok,
                         ModerationStatus::Allowed,
                         Vec::new(),
-                        Some(doc.bytes.to_hex()),
+                        Some(doc.to_url()),
                         req_id,
                     )),
                     (Err(e), _) => Ok(e.to_response(req_id.clone())),
@@ -168,7 +167,7 @@ impl Methods {
                                         RpcStatus::Ok,
                                         ModerationStatus::Allowed,
                                         Vec::new(),
-                                        Some(document.bytes.to_hex()),
+                                        Some(document.to_url()),
                                         req_id,
                                     )),
                                 }

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -47,11 +47,11 @@ impl Methods {
             ) {
                 (Ok(doc), ResponseType::Raw) => Ok(doc.to_response()),
                 (Ok(doc), ResponseType::Json) => Ok(FetchResponse::to_response(
-                    StatusCodes::Ok,
+                    RpcStatus::Ok,
                     ModerationStatus::Allowed,
                     Vec::new(),
                     Some(doc.bytes.to_hex()),
-		    req_id.clone()
+                    req_id,
                 )),
                 (Err(e), _) => Ok(e.to_response(req_id.clone())),
             };
@@ -85,7 +85,7 @@ impl Methods {
                     RpcStatus::Ok,
                     ModerationStatus::Blocked,
                     r.categories.clone(),
-		    None,
+                    None,
                     req_id,
                 ))
             } else {
@@ -95,13 +95,13 @@ impl Methods {
                 ) {
                     (Ok(doc), ResponseType::Raw) => Ok(doc.to_response()),
                     (Ok(doc), ResponseType::Json) => Ok(FetchResponse::to_response(
-                        StatusCodes::Ok,
+                        RpcStatus::Ok,
                         ModerationStatus::Allowed,
                         Vec::new(),
                         Some(doc.bytes.to_hex()),
-			req_id.clone()
+                        req_id,
                     )),
-                    (Err(e), _) => Ok(e.to_response(req_id.clone()))),
+                    (Err(e), _) => Ok(e.to_response(req_id.clone())),
                 }
             }
         } else {
@@ -159,17 +159,17 @@ impl Methods {
                                     ModerationStatus::Blocked,
                                     mr.categories.clone(),
                                     None,
-				    req_id
+                                    req_id,
                                 ))
                             } else {
                                 match params.data {
                                     ResponseType::Raw => Ok(document.to_response()),
                                     ResponseType::Json => Ok(FetchResponse::to_response(
-                                        StatusCodes::Ok,
+                                        RpcStatus::Ok,
                                         ModerationStatus::Allowed,
                                         Vec::new(),
                                         Some(document.bytes.to_hex()),
-					req_id.clone()
+                                        req_id,
                                     )),
                                 }
                             }

--- a/src/rpc/requests.rs
+++ b/src/rpc/requests.rs
@@ -19,9 +19,17 @@ pub struct MethodHeader {
 
 // Fetch method struct
 #[derive(Deserialize)]
+pub enum ResponseType {
+    Json,
+    Raw,
+}
+
+// Fetch method struct
+#[derive(Deserialize)]
 pub struct FetchRequestParams {
     pub url: String,
     pub force: bool,
+    pub data: ResponseType,
 }
 
 #[derive(Deserialize)]

--- a/src/rpc/requests.rs
+++ b/src/rpc/requests.rs
@@ -29,7 +29,7 @@ pub enum ResponseType {
 pub struct FetchRequestParams {
     pub url: String,
     pub force: bool,
-    pub data: ResponseType,
+    pub response_type: ResponseType,
 }
 
 #[derive(Deserialize)]

--- a/src/rpc/responses.rs
+++ b/src/rpc/responses.rs
@@ -34,6 +34,13 @@ pub struct ModerationResult {
 }
 
 #[derive(Serialize)]
+pub struct ErrorResponse {
+    pub jsonrpc: String,
+    pub rpc_status: RpcStatus,
+    pub error: RpcError,
+}
+
+#[derive(Serialize)]
 pub struct FetchResponse {
     pub jsonrpc: String,
     pub rpc_status: RpcStatus,

--- a/src/rpc/responses.rs
+++ b/src/rpc/responses.rs
@@ -38,6 +38,7 @@ pub struct Info {
 pub struct ModerationResult {
     pub moderation_status: ModerationStatus,
     pub categories: Vec<ModerationCategories>,
+    pub data: String,
 }
 
 #[derive(Serialize)]
@@ -107,6 +108,7 @@ impl FetchResponse {
         server_code: StatusCodes,
         moderation_status: ModerationStatus,
         categories: Vec<ModerationCategories>,
+        data: Option<String>,
     ) -> Response<Body> {
         let result = FetchResponse {
             jsonrpc: String::from(VERSION),
@@ -114,6 +116,10 @@ impl FetchResponse {
             result: ModerationResult {
                 moderation_status,
                 categories: categories.clone(),
+                data: match data {
+                    Some(d) => d,
+                    None => String::new(),
+                },
             },
         };
 

--- a/src/rpc/responses.rs
+++ b/src/rpc/responses.rs
@@ -116,10 +116,7 @@ impl FetchResponse {
             result: ModerationResult {
                 moderation_status,
                 categories: categories.clone(),
-                data: match data {
-                    Some(d) => d,
-                    None => String::new(),
-                },
+                data: data.unwrap_or(String::new()),
             },
         };
 


### PR DESCRIPTION
closes #6 
This PR assumes #10 gets merged.
These changes allow the user to specify whether they want data returned to be the raw image or in a json format. The user specifies this with the `data` field in a `img_proxy_fetch` call.

Sample requests:
Json data:
```
{
    "jsonrpc": "1.0.0",
    "method": "img_proxy_fetch",
    "params": {
        "data": "Json",
        "url": "https://upload.wikimedia.org/wikipedia/commons/8/84/Michelangelo%27s_David_2015.jpg",
        "force": false
    }
}
```

Raw data:
```
{
    "jsonrpc": "1.0.0",
    "method": "img_proxy_fetch",
    "params": {
        "data": "Raw",
        "url": "https://upload.wikimedia.org/wikipedia/commons/8/84/Michelangelo%27s_David_2015.jpg",
        "force": false
    }
}
```

Sample Json Responses:
Blocked Image:
```
{
    "jsonrpc": "1.0.0",
    "rpc_status": "Ok",
    "result": {
        "moderation_status": "Blocked",
        "categories": [
            "ExplicitNudity",
            "Suggestive"
        ],
        "data": ""
    }
}
```

Allowed Image:
```
{
    "jsonrpc": "1.0.0",
    "rpc_status": "Ok",
    "result": {
        "moderation_status": "Allowed",
        "categories": [],
        "data": "data:image/jpeg;base64,ffd...0ffd9"
    }
}
```
Still Todo:
- update docs