### PR TITLE
Automatic blocking from reports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -783,6 +783,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135"
 
 [[package]]
+name = "itertools"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1047,10 +1056,12 @@ dependencies = [
  "bb8-postgres",
  "built",
  "chrono",
+ "futures",
  "hocon",
  "hyper",
  "hyper-tls",
  "image",
+ "itertools",
  "lazy_static",
  "log",
  "log4rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,5 @@ tokio-postgres = { version="0.7.2", features=["with-chrono-0_4"] }
 procfs = "0.9.1"
 async-trait = "0.1.50"
 image = "0.23.14"
+futures = { version = "0.3", default-features = false }
+itertools = "0.10.1"

--- a/proxy.conf
+++ b/proxy.conf
@@ -39,7 +39,10 @@
         # Aws specific configuration
         "aws": {
             "region": "us-east-1"
-        }
+        }, 
+
+        # The maximum number of unique reports a url can get before it gets blocked
+        "max_report_strikes": 5
     }
 
     # Database configuration

--- a/sql/imgproxy.sql
+++ b/sql/imgproxy.sql
@@ -46,7 +46,9 @@ CREATE TABLE public.report (
     url character varying(65536) NOT NULL,
     categories character varying(65536),
     url_hash character varying(256),
-    updated_at timestamp with time zone NOT NULL
+    updated_at timestamp with time zone NOT NULL,
+    apikey character varying(512) NOT NULL,
+    ip_addr character varying(512) NOT NULL
 );
 
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -30,6 +30,7 @@ pub struct ModerationConfig {
     pub provider: ModerationService,
     pub aws: Option<AwsConfig>,
     pub labels: Vec<String>, //TODO
+    pub max_report_strikes: usize,
 }
 
 #[derive(Deserialize, Clone)]

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,5 +1,5 @@
 extern crate crypto;
-use std::time::Duration;
+use std::{net::IpAddr, net::Ipv4Addr, time::Duration};
 
 use crate::{
     moderation::{ModerationCategories, ModerationService},
@@ -8,6 +8,8 @@ use crate::{
 use bb8::Pool;
 use bb8_postgres::PostgresConnectionManager;
 use chrono::{DateTime, Utc};
+use futures::future::join_all;
+use itertools::Itertools;
 use log::debug;
 use tokio_postgres::NoTls;
 
@@ -34,6 +36,8 @@ pub struct ReportRow {
     pub url: String,
     pub categories: Vec<ModerationCategories>,
     pub updated_at: DateTime<Utc>,
+    pub apikey: String,
+    pub ip_addr: IpAddr,
 }
 
 impl Database {
@@ -70,18 +74,21 @@ impl Database {
         id: &Uuid,
         url: &str,
         categories: &Vec<ModerationCategories>,
+        addr: &IpAddr,
+        apikey: &String,
     ) -> Result<()> {
         let id = id.to_string();
         let url_hash = Database::sha512(url.as_bytes());
         let timestamp = chrono::Utc::now();
         let cat_str = serde_json::to_string(categories).unwrap_or(String::from("json_error"));
+        let ip_addr = addr.to_string();
         let conn = self.pool.get().await?;
         conn.execute(
-            "INSERT INTO report (id, url, categories, url_hash, updated_at)
-        VALUES($1, $2, $3, $4, $5) 
+            "INSERT INTO report (id, url, categories, url_hash, updated_at, ip_addr, apikey)
+        VALUES($1, $2, $3, $4, $5, $6, $7) 
         ON CONFLICT (id) 
         DO NOTHING;",
-            &[&id, &url, &cat_str, &url_hash, &timestamp],
+            &[&id, &url, &cat_str, &url_hash, &timestamp, &ip_addr, apikey],
         )
         .await?;
         Ok(())
@@ -90,9 +97,11 @@ impl Database {
     pub async fn get_reports(&self) -> Result<Vec<ReportRow>> {
         let conn = self.pool.get().await?;
         let results = conn
-            .query("SELECT id, url, categories, updated_at from report;", &[])
+            .query(
+                "SELECT id, url, categories, updated_at, apikey, ip_addr from report;",
+                &[],
+            )
             .await?;
-
         Ok(results
             .iter()
             .map(|r| {
@@ -102,11 +111,18 @@ impl Database {
                 let categories = serde_json::from_str::<Vec<ModerationCategories>>(&categories)
                     .unwrap_or(Vec::new());
                 let updated_at: DateTime<Utc> = r.get("updated_at");
+                let apikey: &str = r.get("apikey");
+                let string_addr: &str = r.get("ip_addr");
+                let ip_addr: IpAddr = string_addr
+                    .parse()
+                    .unwrap_or(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)));
                 ReportRow {
                     id: String::from(id),
                     url: String::from(url),
-                    categories: categories,
-                    updated_at: updated_at,
+                    apikey: String::from(apikey),
+                    categories,
+                    updated_at,
+                    ip_addr,
                 }
             })
             .collect())
@@ -157,7 +173,11 @@ impl Database {
         Ok(())
     }
 
-    pub async fn get_moderation_result(&self, url: &Vec<String>) -> Result<Vec<DocumentCacheRow>> {
+    pub async fn get_moderation_result(
+        &self,
+        url: &Vec<String>,
+        max_report_strikes: usize,
+    ) -> Result<Vec<DocumentCacheRow>> {
         let url_hashes: Vec<String> = url.iter().map(|u| Database::sha512(u.as_bytes())).collect();
         let conn = self.pool.get().await?;
         let results = conn
@@ -169,20 +189,49 @@ impl Database {
             .await?;
 
         debug!("Retrieved {} rows.", results.len());
+        let report_tally: Vec<usize> = join_all(
+            url_hashes
+                .iter()
+                .map(|hash| self.get_num_reports_for_hash(hash)),
+        )
+        .await
+        .iter()
+        .map(|i| match i {
+            Ok(n) => n.to_owned(),
+            Err(_) => 0,
+        })
+        .collect();
+
+        let report_categories: Vec<Vec<ModerationCategories>> = join_all(
+            url_hashes
+                .iter()
+                .map(|hash| self.get_reported_categories_for_hash(hash)),
+        )
+        .await
+        .iter()
+        .map(|i| match i {
+            Ok(vec) => vec.clone(),
+            Err(_) => Vec::<ModerationCategories>::new(),
+        })
+        .collect();
+
         if results.len() == 0 {
             return Ok(Vec::new());
         }
 
         Ok(results
             .iter()
-            .map(|r| {
-                let blocked: bool = r.get("blocked");
+            .enumerate()
+            .map(move |(i, r)| {
+                let blocked: bool = r.get("blocked") || report_tally[i] > max_report_strikes;
                 let categories: &str = r.get("categories");
                 let provider: &str = r.get("provider");
                 let url: &str = r.get("url");
-
-                let categories = serde_json::from_str::<Vec<ModerationCategories>>(&categories)
-                    .unwrap_or(Vec::new());
+                let categories = match report_tally[i] > max_report_strikes {
+                    true => report_categories[i].clone(),
+                    false => serde_json::from_str::<Vec<ModerationCategories>>(&categories)
+                        .unwrap_or(Vec::new()),
+                };
                 let provider = serde_json::from_str::<ModerationService>(&provider)
                     .unwrap_or(ModerationService::Unknown);
                 DocumentCacheRow {
@@ -193,5 +242,48 @@ impl Database {
                 }
             })
             .collect())
+    }
+
+    pub async fn get_num_reports_for_hash(&self, url_hash: &String) -> Result<usize> {
+        Ok(self
+            .pool
+            .get()
+            .await?
+            .query(
+                "select apikey, ip_addr from report where url_hash=$1 GROUP BY apikey, ip_addr;",
+                &[url_hash],
+            )
+            .await?
+            .len())
+    }
+
+    pub async fn get_reported_categories_for_hash(
+        &self,
+        url_hash: &String,
+    ) -> Result<Vec<ModerationCategories>> {
+        let res = self
+            .pool
+            .get()
+            .await?
+            .query(
+                "select categories from report where url_hash=$1;",
+                &[url_hash],
+            )
+            .await?;
+        let res = res
+            .iter()
+            .map(|r| {
+                let categories: &str = r.get("categories");
+                serde_json::from_str::<Vec<ModerationCategories>>(&categories).unwrap_or(Vec::new())
+            })
+            .fold(Vec::new(), |mut sum, val| {
+                sum.extend(val);
+                sum
+            })
+            .into_iter()
+            .unique()
+            .collect();
+
+        Ok(res)
     }
 }

--- a/src/moderation.rs
+++ b/src/moderation.rs
@@ -81,6 +81,7 @@ impl ModerationProvider for NullProvider {
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub enum ModerationService {
     Aws,
+    Reports,
     Unknown,
     None,
 }

--- a/src/moderation.rs
+++ b/src/moderation.rs
@@ -2,9 +2,7 @@ use async_trait::async_trait;
 use log::warn;
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    aws::Rekognition, config::Configuration, document::Document, rpc::error::Errors,
-};
+use crate::{aws::Rekognition, config::Configuration, document::Document, rpc::error::Errors};
 
 #[derive(PartialEq)]
 pub enum SupportedMimeTypes {
@@ -31,7 +29,7 @@ impl SupportedMimeTypes {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum ModerationCategories {
     ExplicitNudity,
     Suggestive,
@@ -54,10 +52,7 @@ pub struct ModerationResponse {
 /// A trait that all moderation services must implement
 #[async_trait]
 pub trait ModerationProvider: Send + Sync {
-    async fn moderate(
-        self: &Self,
-        document: &Document,
-    ) -> Result<ModerationResponse, Errors>;
+    async fn moderate(self: &Self, document: &Document) -> Result<ModerationResponse, Errors>;
     fn supported_types(self: &Self) -> Vec<SupportedMimeTypes>;
     fn max_document_size(self: &Self) -> u64;
 }

--- a/src/rpc/error.rs
+++ b/src/rpc/error.rs
@@ -1,0 +1,67 @@
+use hyper::{Body, Response};
+use serde::Serialize;
+use uuid::Uuid;
+
+use super::responses::*;
+use super::VERSION;
+
+#[derive(Serialize)]
+pub struct RpcError {
+    pub code: u8,
+    pub reason: String,
+    pub request_id: Uuid,
+}
+
+#[derive(Serialize)]
+pub enum Errors {
+    InvalidRpcVersionError,
+    InvalidRpcMethodError,
+    JsonDecodeError,
+    InternalError,
+    FetchFailed,
+    NotFound,
+    ModerationFailed,
+    UnsupportedImageType,
+    UnsupportedUriScheme,
+    InvalidUri,
+}
+
+impl Errors {
+    fn to_rpc_error(&self, request_id: Uuid) -> RpcError {
+        let (code, reason) = match *self {
+            Errors::InvalidRpcVersionError => (100, "Invalid RPC version".to_string()),
+            Errors::InvalidRpcMethodError => (101, "Invalid RPC method".to_string()),
+            Errors::JsonDecodeError => (102, "Invalid JSON supplied".to_string()),
+            Errors::InternalError => (103, "Internal Error".to_string()),
+            Errors::FetchFailed => (104, "Fetch Failed".to_string()),
+            Errors::NotFound => (105, "Image not found".to_string()),
+            Errors::ModerationFailed => (106, "Image moderation failed".to_string()),
+            Errors::UnsupportedImageType => (107, "Image type unsupported".to_string()),
+            Errors::UnsupportedUriScheme => (108, "Uri scheme unsupported".to_string()),
+            Errors::InvalidUri => (109, "Invalid Uri".to_string()),
+        };
+
+        RpcError {
+            code,
+            reason,
+            request_id,
+        }
+    }
+
+    pub fn to_response(&self, request_id: Uuid) -> Response<Body> {
+        let error = self.to_rpc_error(request_id);
+
+        let body = serde_json::to_string_pretty(&ErrorResponse {
+            jsonrpc: VERSION.to_string(),
+            rpc_status: RpcStatus::Err,
+            error: error,
+        })
+        .unwrap_or_default()
+        .clone();
+        Response::builder()
+            .status(hyper::StatusCode::OK)
+            .header(hyper::header::CONTENT_TYPE, "application/json")
+            .body(Body::from(body))
+            .unwrap_or_default()
+    }
+}


### PR DESCRIPTION
This PR allows the image proxy to automatically block urls after a certain number of unique reports have been made on that url. This number is set via `proxy.conf` in the `max_report_strikes` field. Uniqueness is determined by looking at apikey, ip addr pairs.