### PR TITLE
Resize logic will now ignore content length header

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -54,7 +54,7 @@ impl Document {
     ) -> Result<Document, Errors> {
         let img = self.load_image(image_type)?;
         let (x_dim, y_dim) = img.dimensions();
-        let scale = self.content_length as f64 / max_size as f64;
+        let scale = self.bytes.len() as f64 / max_size as f64;
         let scale_factor: u32 = 2_u32.pow(scale.max(0_f64) as u32);
         debug!("Image resize: scale={}, factor={}", scale, scale_factor);
         let (x_dim_new, y_dim_new) = (x_dim / scale_factor, y_dim / scale_factor);

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -151,7 +151,7 @@ impl Methods {
             metrics::MODERATION.with_label_values(&["requests"]).inc();
 
             // Resize the image if required or reformat to png if required
-            let formatted: Result<ModerationResponse, Errors> = if document.content_length
+            let formatted: Result<ModerationResponse, Errors> = if document.bytes.len() as u64
                 >= max_document_size
                 || !supported_types.contains(&document_type)
             {


### PR DESCRIPTION
Some IPFS nodes do not return a valid `content-length` header. This fix switches internal calculations to compute content length dynamically using the returned response.