### PR TITLE
Fixed an issue to make sure all the  top level categories are selected from aws rekognition  response

### DIFF
--- a/src/aws/messages.rs
+++ b/src/aws/messages.rs
@@ -14,9 +14,10 @@ pub struct Label {
 
 impl Label {
     pub fn top_category(&self) -> &str {
-        match self.ParentName.is_empty() {
-            true => &self.Name,
-            _ => &self.ParentName,
+        if self.ParentName.is_empty() {
+            &self.Name
+        } else {
+            &self.ParentName
         }
     }
 }

--- a/src/aws/messages.rs
+++ b/src/aws/messages.rs
@@ -35,7 +35,6 @@ impl RekognitionResponse {
             .ModerationLabels
             .iter()
             .map(|l| l.top_category().to_owned())
-            .filter(|l| !l.is_empty())
             .collect();
         labels
             .iter()

--- a/src/aws/messages.rs
+++ b/src/aws/messages.rs
@@ -13,10 +13,10 @@ pub struct Label {
 }
 
 impl Label {
-    pub fn get_top_level_category(&self) -> String {
+    pub fn top_category(&self) -> &str {
         match self.ParentName.is_empty() {
-            true => self.Name.clone(),
-            _ => self.ParentName.clone(),
+            true => &self.Name,
+            _ => &self.ParentName,
         }
     }
 }
@@ -33,7 +33,7 @@ impl RekognitionResponse {
         let labels: HashSet<String> = self
             .ModerationLabels
             .iter()
-            .map(|l| l.get_top_level_category())
+            .map(|l| l.top_category().to_owned())
             .filter(|l| !l.is_empty())
             .collect();
         labels

--- a/src/aws/messages.rs
+++ b/src/aws/messages.rs
@@ -12,6 +12,15 @@ pub struct Label {
     pub ParentName: String,
 }
 
+impl Label {
+    pub fn get_top_level_category(&self) -> String {
+        match self.ParentName.is_empty() {
+            true => self.Name.clone(),
+            _ => self.ParentName.clone(),
+        }
+    }
+}
+
 #[derive(Deserialize)]
 #[allow(non_snake_case)]
 pub struct RekognitionResponse {
@@ -24,7 +33,7 @@ impl RekognitionResponse {
         let labels: HashSet<String> = self
             .ModerationLabels
             .iter()
-            .map(|l| l.ParentName.clone())
+            .map(|l| l.get_top_level_category())
             .filter(|l| !l.is_empty())
             .collect();
         labels


### PR DESCRIPTION
added a function to the implementation of  Label for correctly getting the top-level category returned  by aws, this improves on the existing solution of only looking for the top-level category in Label.ParentName,  by  looking at both ParentName and Name