### PR TITLE
Added support for useragent header in outgoing requests

### DIFF
--- a/proxy.conf
+++ b/proxy.conf
@@ -33,6 +33,12 @@
     # Time out in seconds for request,response and connecting to a url
     "timeout": 100
 
+    # Optional useragent header value to be sent when fetching content.
+    # Commenting out the config means no useragent header will be set in 
+    # the outgoing request. This may lead to some destination servers
+    # rejecting the request.
+    "client_useragent": "ImageProxy/1.0"
+
     "security" : {
         # Api access keys. Random ones provided below for testing, replace with your
         # list. Note that if metrics is enabled, key usage stats will be displayed

--- a/src/config.rs
+++ b/src/config.rs
@@ -66,6 +66,7 @@ pub struct Configuration {
     pub metrics_enabled: bool,
     pub dashboard_enabled: bool,
     pub max_document_size: Option<u64>,
+    pub client_useragent: Option<String>,
     pub security: SecurityConfig,
     pub database: DatabaseConfig,
     pub moderation: ModerationConfig,

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -148,7 +148,7 @@ impl HttpClientWrapper {
     }
 }
 
-pub struct HttpClientFactory {}
+pub struct HttpClientFactory;
 
 impl HttpClientFactory {
     pub fn get_provider(
@@ -156,13 +156,14 @@ impl HttpClientFactory {
         max_document_size: Option<u64>,
         uri_filters: Vec<Box<dyn UriFilter + Send + Sync>>,
         timeout: u64,
+        useragent: Option<String>,
     ) -> HttpClientWrapper {
         assert!(
             !uri_filters.is_empty(),
             "No URI filters provided. This is insecure, check code. Exiting..."
         );
         HttpClientWrapper {
-            client: Box::new(HyperHttpClient::new(max_document_size, timeout)),
+            client: Box::new(HyperHttpClient::new(max_document_size, timeout, useragent)),
             ipfs_config,
             uri_filters,
         }
@@ -186,7 +187,7 @@ mod tests {
         let uri_filters: Vec<Box<dyn UriFilter + Send + Sync>> = vec![Box::new(
             PrivateNetworkFilter::new(Box::new(StandardDnsResolver {})),
         )];
-        let wrapper = HttpClientFactory::get_provider(ipfs_config, None, uri_filters, 10_u64);
+        let wrapper = HttpClientFactory::get_provider(ipfs_config, None, uri_filters, 10_u64, None);
 
         // Valid https url
         let result = wrapper.to_uri("https://localhost:3422/image.png");

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -63,6 +63,7 @@ impl Context {
             config.max_document_size,
             uri_filters,
             config.timeout,
+            config.client_useragent.clone(),
         );
         Ok(Context {
             database,


### PR DESCRIPTION
Previously all HTTP requests for fetching content did not contain the `user-agent` header. Omitting this header can potentially cause the destination server to reject the request, thus failing the entire `fetch` query.

This change adds an optional config item called `client_useragent`. When a value is set, the header `user-agent` and the set value will be included in all outgoing HTTP requests.

Closes #43 