### PR TITLE
Update cargo manifest to exclude non rust files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -943,9 +943,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9de88456263e249e241fcd211d3954e2c9b0ef7ccfc235a444eb367cae3689"
+checksum = "d9f1f717ddc7b2ba36df7e871fd88db79326551d3d6f1fc406fbfd28b582ff8e"
 dependencies = [
  "bytes",
  "fnv",
@@ -1262,9 +1262,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.114"
+version = "0.2.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0005d08a8f7b65fb8073cb697aa0b12b631ed251ce73d862ce50eeb52ce3b50"
+checksum = "0a8d982fa7a96a000f6ec4cfe966de9703eccde29750df2bb8949da91b0e818d"
 
 [[package]]
 name = "libgit2-sys"
@@ -1451,7 +1451,7 @@ dependencies = [
 
 [[package]]
 name = "nft_image_proxy"
-version = "1.4.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2285,9 +2285,9 @@ checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
 name = "socket2"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f82496b90c36d70af5fcd482edaa2e0bd16fade569de1330405fecbbdac736b"
+checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
 dependencies = [
  "libc",
  "winapi",
@@ -2902,6 +2902,6 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc222aec311c323c717f56060324f32b82da1ce1dd81d9a09aa6a9030bfe08db"
+checksum = "4062c749be08d90be727e9c5895371c3a0e49b90ba2b9592dc7afda95cc2b719"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "nft_image_proxy"
 version = "1.4.0"
+repository = "https://github.com/Cryptonomic/ImageProxy"
 authors = ["Cryptonomic Inc."]
 edition = "2018"
 build = "build.rs"
+exclude = ["/docker", "/docs", "/lib", "/log", "proxy.conf", "/*.yml", "/.github", "Dockerfile", "LICENSE", "README.md", ".gitignore", ".dockerignore"]
 
 [build-dependencies]
 built = { version = "0.5", features = ["git2"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nft_image_proxy"
-version = "1.4.0"
+version = "2.0.0"
 repository = "https://github.com/Cryptonomic/ImageProxy"
 authors = ["Cryptonomic Inc."]
 edition = "2018"


### PR DESCRIPTION
Cargo has been tracking several non rust files and  leads to a poor developer experience. This updates the manifest to exclude these files. Refer issue #85.

Also the package version has been bumped to `2.0.0`. 
